### PR TITLE
Tabzilla should not get the content direction

### DIFF
--- a/media/css/tabzilla.css
+++ b/media/css/tabzilla.css
@@ -89,6 +89,7 @@
     -ms-transition: all 0.2s ease-in-out;
     transition: all 0.2s ease-in-out;
     overflow: hidden;
+    direction: ltr;
 }
 
 #tabzilla-panel.tabzilla-opened {


### PR DESCRIPTION
While Tabzilla is not (yet!) localizable, it is important to keep an eye on situations that could happen with RTL webpages that add the tab to them. 

Until the content would be localizable, we just need to make sure the tab content will be always LTR. this can be made by hardcoding the stylesheet to display the tab in LTR, and will have no affect if the whole page is in LTR as the case to most of us. 

The other option could be to place yet additional stylesheet rule on any of these websites, with the same rule, but I prefer the previous option instead.

I've patched the code and this is the pull request. If you prefer me to push it to other repo, please let me know and I'll fix it ASAP.

Thanks, and happy hacking. ☺

Tomer.
