### PR TITLE
Bug 796151 - Boot to Gecko is now Firefox OS

### DIFF
--- a/media/js/tabzilla.js
+++ b/media/js/tabzilla.js
@@ -549,7 +549,7 @@ Tabzilla.content =
     + '        <ul>'
     + '          <li><a href="http://www.mozilla.org/firefox">Firefox</a></li>'
     + '          <li><a href="http://www.mozilla.org/thunderbird">Thunderbird</a></li>'
-    + '          <li><a href="http://www.mozilla.org/b2g">Boot to Gecko</a></li>'
+    + '          <li><a href="http://www.mozilla.org/firefoxos">Firefox OS</a></li>'
     + '        </ul>'
     + '      </li>'
     + '      <li><h2>Innovations</h2>'


### PR DESCRIPTION
This can go live as soon as the Firefox OS page is live.
