### PR TITLE
jQuery wouldn't be added if Tabzilla was appended to the DOM after it had loaded

### DIFF
--- a/media/js/tabzilla.js
+++ b/media/js/tabzilla.js
@@ -176,7 +176,12 @@ Tabzilla.run = function()
     // FireFox and Opera: These browsers provide a event for this
     // moment.  The latest WebKit releases now support this event.
     } else {
-        Tabzilla.addEventListener(document, 'DOMContentLoaded', Tabzilla.ready);
+        var rs = document.readyState;
+        if (rs == 'interactive' || rs == 'complete') {
+            Tabzilla.ready();
+        } else {
+            Tabzilla.addEventListener(document, 'DOMContentLoaded', Tabzilla.ready);
+        }
     }
 };
 
@@ -197,9 +202,6 @@ Tabzilla.ready = function()
         // if we don't have jQuery, dynamically load jQuery from CDN
         if (typeof jQuery == 'undefined') {
             var script = document.createElement('script');
-            script.type = 'text/javascript';
-            script.src = Tabzilla.jQueryCDNSrc;
-            document.getElementsByTagName('body')[0].appendChild(script);
 
             if (script.readyState) {
                 // IE
@@ -214,6 +216,10 @@ Tabzilla.ready = function()
                 // Others
                 script.onload = onLoad;
             }
+
+            script.type = 'text/javascript';
+            script.src = Tabzilla.jQueryCDNSrc;
+            document.getElementsByTagName('body')[0].appendChild(script);
         } else {
             onLoad();
         }
@@ -531,7 +537,7 @@ Tabzilla.content =
     + '    <div class="snippet" id="tabzilla-promo-social">'
     + '    <a href="http://www.facebook.com/fxmessenger">'
     + '     <h4>Facebook Messenger for Firefox</h4>'
-    + '     <p>Visit Facebook to turn it on »</p>'
+    + '     <p>Visit Facebook to turn it on »</p>'
     + '    </a>'
     + '    </div>'
     + '  </div>'


### PR DESCRIPTION
Right now the code that is present to add jQuery to the page if it isn't present will only fire if the Tabzilla script was included already in the DOM when the page is loading. This is because of the reliance on listening for DOMContentLoaded ( or the equivalent for older browsers ).

We don't specifically encounter this problem right now with Popcorn Maker because we only have a single template being used in our system however soon enough it will be moving back to a multiple template system and relying on people to appropriate include scripts wouldn't be fun. On our end we need to move to including Tabzilla as part of the application itself which means including the script after the DOMContentLoaded event has fired.
