### PR TITLE
Ignore .DS_Store files in Tabzilla repo

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,2 @@
 node_modules
+.DS_Store


### PR DESCRIPTION
Darn .DS_Store files need to be ignored :)