### PR TITLE
Update @highdip to use single quotes

### DIFF
--- a/less/lib/lib.less
+++ b/less/lib/lib.less
@@ -21,7 +21,7 @@
     background-image: url(@path);
     @at2x_path: ~`@{path}.replace(/\.\w+$/, function(match) { return "-high-res" + match; })`;
     @media @highdpi {
-        background-image: url("@{at2x_path}");
+        background-image: url('@{at2x_path}');
         -webkit-background-size: @w @h;
                 background-size: @w @h;
     }


### PR DESCRIPTION
As per CSS style guide.

Please note: I do not have LESS installed and did not test this change locally. Maybe it was done with double quotes to work around a LESS parsing limitation? I don't know. Hopefully you do.